### PR TITLE
added blank line to end of cron file to fix issue on some linux syste…

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 echo "creating crontab"
-echo "$CRON_SCHEDULE /dobackup.sh" > /etc/crontabs/root
+echo -e "$CRON_SCHEDULE /dobackup.sh\n" > /etc/crontabs/root
 echo "starting crond"
 crond -f


### PR DESCRIPTION
…ms where cron job will not run if blank line at the end of file is missing. https://askubuntu.com/questions/23009/reasons-why-crontab-does-not-work