### PR TITLE
Removed quotes from the target env variable

### DIFF
--- a/dobackup.sh
+++ b/dobackup.sh
@@ -25,7 +25,7 @@ else
 fi
 
 echo "creating archive"
-tar -zcvf "${FILE_NAME}" "${TARGET}"
+tar -zcvf "${FILE_NAME}" ${TARGET}
 echo "uploading archive to S3 [${FILE_NAME}, storage class - ${S3_STORAGE_CLASS}]"
 aws s3 ${AWS_ARGS} cp --storage-class "${S3_STORAGE_CLASS}" "${FILE_NAME}" "${S3_BUCKET_URL}"
 echo "removing local archive"


### PR DESCRIPTION
This broke specifying multiple targets as tar would treat it as 1 file instead of multiple. I have checked this still works when `TARGET` is unset.

For example:
```
tar -zcvf something.tar.gz a/ b/
```

would insert the `a` and `b` folder in the archive while

```
tar -zcvf something.tar.gz "a/ b/"
```

would try to add the `a/ b/` folder, which doesn't exist. 