### PR TITLE
Update dobackup.sh to allow manual trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ From a security perspective it is often preferable to create a dedicated IAM use
 }
 ```
 
+### Trigger backup manually
+
+Run the following command to trigger a backup manually on a running container:
+
+```
+docker exec -u backup -it ${CONTAINER_ID} sh dobackup.sh
+```
+
 ## It doesn't do X or Y!
 
 Let this container serve as a starting point and an inspiration! Feel free to modify it and even open a PR if you feel others can benefit from these changes.

--- a/dobackup.sh
+++ b/dobackup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-source .env
+source /home/backup/.env
 
 # default storage class to standard if not provided
 S3_STORAGE_CLASS=${S3_STORAGE_CLASS:-STANDARD}


### PR DESCRIPTION
Minor change to `dobackup.sh` as I wanted to manually trigger the backup from outside the container.

This is helpful for manual triggers but also makes it easier to test.

Currently:
- `entrypoint.sh` writes to `/home/backup/.env`
- `dobackup.sh` reads the env from `.env` which works but doesn't for manual triggers. This part confuses me because I don't quite get how it works currently.  

My change:
- Makes the path absolute.  Which seems to work with this new functionality as well as existing.

The README is updated as well to explain how to use this new functionality.